### PR TITLE
Switched to .Net Standard build.

### DIFF
--- a/ETLBox/ETLBox.csproj
+++ b/ETLBox/ETLBox.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+		<TargetFramework>netstandard2.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>It's all in the box! Run all your ETL jobs with this awesome C# class library.

--- a/ETLBox/src/Definitions/ConnectionStrings/ConnectionString.cs
+++ b/ETLBox/src/Definitions/ConnectionStrings/ConnectionString.cs
@@ -1,5 +1,8 @@
 ﻿using System.Data.SqlClient;
 
+// for string extensions
+using ALE.ETLBox.Helper;
+
 namespace ALE.ETLBox {
     /// <summary>
     /// A helper class for encapsulating a conection string to a sql server in an object.
@@ -11,7 +14,7 @@ namespace ALE.ETLBox {
 
         public string Value {
             get {
-                return _builder?.ConnectionString.Replace("Integrated Security=true", "Integrated Security=SSPI", System.StringComparison.InvariantCultureIgnoreCase);
+                return _builder?.ConnectionString.ReplaceIgnoreCase("Integrated Security=true", "Integrated Security=SSPI");
             }
             set {
                 _builder = new SqlConnectionStringBuilder(value);

--- a/ETLBox/src/Helper/StringExtension.cs
+++ b/ETLBox/src/Helper/StringExtension.cs
@@ -1,5 +1,33 @@
 ﻿namespace ALE.ETLBox.Helper {
     public static class StringExtension {
         public static string NullOrSqlString(this string s) => s == null ? "null" : $"'{s.Replace("'","''")}'";
-    }
+
+		/// <summary>
+		///		This replicates the functionality of case-insensitive functionality built into Replace in .Net Core.
+		/// </summary>
+		/// <param name="toSearch"></param>
+		/// <param name="find"></param>
+		/// <param name="replace"></param>
+		/// <returns></returns>
+		public static string ReplaceIgnoreCase(this string toSearch, string find, string replace)
+		{
+			int index = toSearch.IndexOf(
+				find,
+				System.StringComparison.InvariantCultureIgnoreCase);
+
+			if (index < 0)
+			{
+				return toSearch;
+			}
+
+			string replacement = toSearch.Substring(0, index) + replace;
+
+			if (toSearch.Length > index + find.Length)
+			{
+				replacement += toSearch.Substring(index + find.Length);
+			}
+
+			return replacement;
+		}
+	}
 }

--- a/ETLBox/src/Toolbox/DataFlow/DBSource.cs
+++ b/ETLBox/src/Toolbox/DataFlow/DBSource.cs
@@ -74,7 +74,7 @@ namespace ALE.ETLBox.DataFlow
             List<string> columNames = statement?.Select
                                                 .Tokens
                                                 .Where(token => token.Type == TSQL.Tokens.TSQLTokenType.Identifier)
-                                                .Select(token => token.Text)
+                                                .Select(token => token.AsIdentifier.Name)
                                                 .ToList();
             return columNames;
         }

--- a/ETLBoxTest/src/Helper/TestStringExtensions.cs
+++ b/ETLBoxTest/src/Helper/TestStringExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using ALE.ETLBox.Helper;
+
+namespace ALE.ETLBoxTest
+{
+	[TestClass]
+	public class TestStringExtensions
+	{
+		[TestMethod]
+		public void TestStringReplaceNotExist()
+		{
+			Assert.AreEqual("test", "test".ReplaceIgnoreCase("something", "replacement"));
+		}
+
+		[TestMethod]
+		public void TestStringReplaceDiffCase()
+		{
+			Assert.AreEqual("test other thing", "test some thing".ReplaceIgnoreCase("SOME", "other"));
+		}
+
+		[TestMethod]
+		public void TestStringReplaceExactLength()
+		{
+			Assert.AreEqual("test this", "test thing".ReplaceIgnoreCase("thing", "this"));
+		}
+	}
+}


### PR DESCRIPTION
Seems to accept same dependencies as .Net Core build, and seems to build successfully after one small workaround for functionality that only exists in .Net Core.