### PR TITLE
Add TConvert generic method type to IDataFlowLinkSource.LinkTo

### DIFF
--- a/ETLBox/src/Definitions/DataFlow/DataFlowLinker.cs
+++ b/ETLBox/src/Definitions/DataFlow/DataFlowLinker.cs
@@ -22,21 +22,33 @@ namespace ALE.ETLBox.DataFlow
 
         public IDataFlowLinkSource<TOutput> LinkTo(IDataFlowLinkTarget<TOutput> target)
         {
+            return LinkTo<TOutput>(target);
+        }
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target)
+        {
             SourceBlock.LinkTo(target.TargetBlock, new DataflowLinkOptions() { PropagateCompletion = true });
             if (!DisableLogging)
                 NLogger.Debug(CallingTask.TaskName + " was linked to Target!", CallingTask.TaskType, "LOG", CallingTask.TaskHash, ControlFlow.ControlFlow.STAGE, ControlFlow.ControlFlow.CurrentLoadProcess?.LoadProcessKey);
-            return target as IDataFlowLinkSource<TOutput>;
+            return target as IDataFlowLinkSource<TConvert>;
         }
 
         public IDataFlowLinkSource<TOutput> LinkTo(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> predicate)
         {
+            return LinkTo<TOutput>(target, predicate);
+        }
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> predicate)
+        {
             SourceBlock.LinkTo(target.TargetBlock, new DataflowLinkOptions() { PropagateCompletion = true }, predicate);
             if (!DisableLogging)
                 NLogger.Debug(CallingTask.TaskName + " was linked to Target (with predicate)!", CallingTask.TaskType, "LOG", CallingTask.TaskHash, ControlFlow.ControlFlow.STAGE, ControlFlow.ControlFlow.CurrentLoadProcess?.LoadProcessKey);
-            return target as IDataFlowLinkSource<TOutput>;
+            return target as IDataFlowLinkSource<TConvert>;
         }
 
         public IDataFlowLinkSource<TOutput> LinkTo(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> rowsToKeep, Predicate<TOutput> rowsIntoVoid)
+        {
+            return LinkTo<TOutput>(target, rowsToKeep, rowsIntoVoid);
+        }
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> rowsToKeep, Predicate<TOutput> rowsIntoVoid)
         {
             SourceBlock.LinkTo(target.TargetBlock, new DataflowLinkOptions() { PropagateCompletion = true }, rowsToKeep);
             if (!DisableLogging)
@@ -46,8 +58,7 @@ namespace ALE.ETLBox.DataFlow
             if (!DisableLogging)
                 NLogger.Debug(CallingTask.TaskName + " was also linked to VoidDestination to ignore certain rows!", CallingTask.TaskType, "LOG", CallingTask.TaskHash, ControlFlow.ControlFlow.STAGE, ControlFlow.ControlFlow.CurrentLoadProcess?.LoadProcessKey);
 
-            return target as IDataFlowLinkSource<TOutput>;
+            return target as IDataFlowLinkSource<TConvert>;
         }
-
     }
 }

--- a/ETLBox/src/Definitions/DataFlow/IDataFlowLinkSource.cs
+++ b/ETLBox/src/Definitions/DataFlow/IDataFlowLinkSource.cs
@@ -6,10 +6,12 @@ namespace ALE.ETLBox.DataFlow
     public interface IDataFlowLinkSource<TOutput>
     {
         ISourceBlock<TOutput> SourceBlock { get; }
-        IDataFlowLinkSource<TOutput> LinkTo(IDataFlowLinkTarget<TOutput> target);
-        IDataFlowLinkSource<TOutput> LinkTo(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> predicate);
-
+        IDataFlowLinkSource<TOutput> LinkTo(IDataFlowLinkTarget<TOutput> target);        
+        IDataFlowLinkSource<TOutput> LinkTo(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> predicate);        
         IDataFlowLinkSource<TOutput> LinkTo(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> rowsToKeep, Predicate<TOutput> rowsIntoVoid);
-
+        
+        IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target);
+        IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> predicate);
+        IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> rowsToKeep, Predicate<TOutput> rowsIntoVoid);
     }
 }

--- a/ETLBox/src/Definitions/TaskBase/DataFlowSource.cs
+++ b/ETLBox/src/Definitions/TaskBase/DataFlowSource.cs
@@ -34,6 +34,15 @@ namespace ALE.ETLBox.DataFlow
         public IDataFlowLinkSource<TOutput> LinkTo(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> rowsToKeep, Predicate<TOutput> rowsIntoVoid)
             => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo(target, rowsToKeep, rowsIntoVoid);
 
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target)
+            => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> predicate)
+            => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target, predicate);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> rowsToKeep, Predicate<TOutput> rowsIntoVoid)
+            => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target, rowsToKeep, rowsIntoVoid);
+
         internal void NLogStart()
         {
             if (!DisableLogging)

--- a/ETLBox/src/Toolbox/DataFlow/BlockTransformation.cs
+++ b/ETLBox/src/Toolbox/DataFlow/BlockTransformation.cs
@@ -102,7 +102,15 @@ namespace ALE.ETLBox.DataFlow
 
         public IDataFlowLinkSource<TOutput> LinkTo(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> rowsToKeep, Predicate<TOutput> rowsIntoVoid)
             => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo(target, rowsToKeep, rowsIntoVoid);
+        
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target) 
+            => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target);
 
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> predicate)
+            => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target, predicate);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> rowsToKeep, Predicate<TOutput> rowsIntoVoid)
+            => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target, rowsToKeep, rowsIntoVoid);
 
         void NLogStart()
         {
@@ -124,7 +132,6 @@ namespace ALE.ETLBox.DataFlow
             if (!DisableLogging && HasLoggingThresholdRows && (ProgressCount % LoggingThresholdRows == 0))
                 NLogger.Info(TaskName + $" processed {ProgressCount} records.", TaskType, "LOG", TaskHash, ControlFlow.ControlFlow.STAGE, ControlFlow.ControlFlow.CurrentLoadProcess?.LoadProcessKey);
         }
-
     }
 
     /// <summary>

--- a/ETLBox/src/Toolbox/DataFlow/DBMerge.cs
+++ b/ETLBox/src/Toolbox/DataFlow/DBMerge.cs
@@ -190,6 +190,15 @@ namespace ALE.ETLBox.DataFlow
         public IDataFlowLinkSource<TInput> LinkTo(IDataFlowLinkTarget<TInput> target, Predicate<TInput> rowsToKeep, Predicate<TInput> rowsIntoVoid)
             => OutputSource.LinkTo(target, rowsToKeep, rowsIntoVoid);
 
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TInput> target)
+            => OutputSource.LinkTo<TConvert>(target);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TInput> target, Predicate<TInput> predicate)
+            => OutputSource.LinkTo<TConvert>(target, predicate);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TInput> target, Predicate<TInput> rowsToKeep, Predicate<TInput> rowsIntoVoid)
+            => OutputSource.LinkTo<TConvert>(target, rowsToKeep, rowsIntoVoid);
+
         public ISourceBlock<TInput> SourceBlock => OutputSource.SourceBlock;
 
     }

--- a/ETLBox/src/Toolbox/DataFlow/Lookup.cs
+++ b/ETLBox/src/Toolbox/DataFlow/Lookup.cs
@@ -112,6 +112,14 @@ namespace ALE.ETLBox.DataFlow
         public IDataFlowLinkSource<TTransformationOutput> LinkTo(IDataFlowLinkTarget<TTransformationOutput> target, Predicate<TTransformationOutput> rowsToKeep, Predicate<TTransformationOutput> rowsIntoVoid)
             => RowTransformation.LinkTo(target, rowsToKeep, rowsIntoVoid);
 
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TTransformationOutput> target)
+            => RowTransformation.LinkTo<TConvert>(target);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TTransformationOutput> target, Predicate<TTransformationOutput> predicate)
+            => RowTransformation.LinkTo<TConvert>(target, predicate);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TTransformationOutput> target, Predicate<TTransformationOutput> rowsToKeep, Predicate<TTransformationOutput> rowsIntoVoid)
+            => RowTransformation.LinkTo<TConvert>(target, rowsToKeep, rowsIntoVoid);
     }
 
     /// <summary>

--- a/ETLBox/src/Toolbox/DataFlow/MergeJoin.cs
+++ b/ETLBox/src/Toolbox/DataFlow/MergeJoin.cs
@@ -75,6 +75,14 @@ namespace ALE.ETLBox.DataFlow
         public IDataFlowLinkSource<TOutput> LinkTo(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> rowsToKeep, Predicate<TOutput> rowsIntoVoid)
             => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo(target, rowsToKeep, rowsIntoVoid);
 
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target)
+            => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> predicate)
+            => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target, predicate);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> rowsToKeep, Predicate<TOutput> rowsIntoVoid)
+            => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target, rowsToKeep, rowsIntoVoid);
     }
 
     public class MergeJoinTarget<TInput> : IDataFlowDestination<TInput>

--- a/ETLBox/src/Toolbox/DataFlow/Multicast.cs
+++ b/ETLBox/src/Toolbox/DataFlow/Multicast.cs
@@ -48,6 +48,15 @@ namespace ALE.ETLBox.DataFlow
         public IDataFlowLinkSource<TInput> LinkTo(IDataFlowLinkTarget<TInput> target, Predicate<TInput> rowsToKeep, Predicate<TInput> rowsIntoVoid)
             => (new DataFlowLinker<TInput>(this, SourceBlock, DisableLogging)).LinkTo(target, rowsToKeep, rowsIntoVoid);
 
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TInput> target)
+            => (new DataFlowLinker<TInput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TInput> target, Predicate<TInput> predicate)
+            => (new DataFlowLinker<TInput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target, predicate);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TInput> target, Predicate<TInput> rowsToKeep, Predicate<TInput> rowsIntoVoid)
+            => (new DataFlowLinker<TInput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target, rowsToKeep, rowsIntoVoid);
+
         private TInput Clone(TInput row)
         {
             TInput clone = default(TInput);
@@ -76,6 +85,7 @@ namespace ALE.ETLBox.DataFlow
             if (!DisableLogging && HasLoggingThresholdRows && (ProgressCount % LoggingThresholdRows == 0))
                 NLogger.Info(TaskName + $" processed {ProgressCount} records.", TaskType, "LOG", TaskHash, ControlFlow.ControlFlow.STAGE, ControlFlow.ControlFlow.CurrentLoadProcess?.LoadProcessKey);
         }
+
     }
 
     /// <summary>

--- a/ETLBox/src/Toolbox/DataFlow/RowTransformation.cs
+++ b/ETLBox/src/Toolbox/DataFlow/RowTransformation.cs
@@ -96,6 +96,15 @@ namespace ALE.ETLBox.DataFlow
         public IDataFlowLinkSource<TOutput> LinkTo(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> rowsToKeep, Predicate<TOutput> rowsIntoVoid)
             => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo(target, rowsToKeep, rowsIntoVoid);
 
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target)
+            => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> predicate)
+            => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target, predicate);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TOutput> target, Predicate<TOutput> rowsToKeep, Predicate<TOutput> rowsIntoVoid)
+            => (new DataFlowLinker<TOutput>(this, SourceBlock, DisableLogging)).LinkTo<TConvert>(target, rowsToKeep, rowsIntoVoid);
+
         private TOutput InvokeRowTransformationFunc(TInput row)
         {
             if (!WasInitialized)
@@ -115,6 +124,7 @@ namespace ALE.ETLBox.DataFlow
             if (!DisableLogging && HasLoggingThresholdRows && (ProgressCount % LoggingThresholdRows == 0))
                 NLogger.Info(TaskName + $" processed {ProgressCount} records.", TaskType, "LOG", TaskHash, ControlFlow.ControlFlow.STAGE, ControlFlow.ControlFlow.CurrentLoadProcess?.LoadProcessKey);
         }
+
     }
 
     /// <summary>

--- a/ETLBox/src/Toolbox/DataFlow/Sort.cs
+++ b/ETLBox/src/Toolbox/DataFlow/Sort.cs
@@ -70,6 +70,14 @@ namespace ALE.ETLBox.DataFlow
         public IDataFlowLinkSource<TInput> LinkTo(IDataFlowLinkTarget<TInput> target, Predicate<TInput> rowsToKeep, Predicate<TInput> rowsIntoVoid)
             => BlockTransformation.LinkTo(target, rowsToKeep, rowsIntoVoid);
 
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TInput> target)
+            => BlockTransformation.LinkTo<TConvert>(target);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TInput> target, Predicate<TInput> predicate)
+            => BlockTransformation.LinkTo<TConvert>(target, predicate);
+
+        public IDataFlowLinkSource<TConvert> LinkTo<TConvert>(IDataFlowLinkTarget<TInput> target, Predicate<TInput> rowsToKeep, Predicate<TInput> rowsIntoVoid)
+            => BlockTransformation.LinkTo<TConvert>(target, rowsToKeep, rowsIntoVoid);
     }
 
     /// <summary>


### PR DESCRIPTION
Hi there,

Thank you for releasing 1.6.2 the other day, I have just been looking at integrating the changes into my codebase.

One of the things I need to do is to be able to change the type of the poco during the flow of the transformation blocks.

```c#
DBSource<TypeA> source = new DBSource<TypeA>("dbo.TypeA');
DBDestination<TypeB> destination = new DBDestination<TypeB>("dbo.TypeB');
RowTransformation<TypeA, TypeB> transform = new RowTransformation<TypeA, TypeB>(...);

source.LinkTo<TypeB>(transform).LinkTo(destination);
```

I would appreciate if you would consider this kind of change.

Kind regards,
Ben