### PR TITLE
DestinationTableDefinition safety checked and fallback to TableName

### DIFF
--- a/ETLBox/src/Toolbox/DataFlow/DBDestination.cs
+++ b/ETLBox/src/Toolbox/DataFlow/DBDestination.cs
@@ -20,7 +20,7 @@ namespace ALE.ETLBox.DataFlow
     public class DBDestination<TInput> : DataFlowBatchDestination<TInput>, ITask, IDataFlowDestination<TInput>
     {
         /* ITask Interface */
-        public override string TaskName => $"Dataflow: Write Data batchwise into table {DestinationTableDefinition.Name}";
+        public override string TaskName => $"Dataflow: Write Data batchwise into table {DestinationTableDefinition?.Name ?? TableName}";
         /* Public properties */
         public TableDefinition DestinationTableDefinition { get; set; }
         public bool HasDestinationTableDefinition => DestinationTableDefinition != null;


### PR DESCRIPTION
Hi,

I experienced a problem earlier with a null ref exception evaluating task name when using a DBDestination declared thus -

```c#
DBDestination<TypeA>(this.connection, "dbo.tableA");
```

Kind regards,