### PR TITLE
Expose destination completion tasks so several can be awaited at once

### DIFF
--- a/ETLBox/src/Definitions/DataFlow/IDataFlowDestination.cs
+++ b/ETLBox/src/Definitions/DataFlow/IDataFlowDestination.cs
@@ -5,6 +5,6 @@ namespace ALE.ETLBox.DataFlow
     public interface IDataFlowDestination<TInput> : IDataFlowLinkTarget<TInput>
     {
         void Wait();
-        Task Completion();
+        Task Completion { get; }
     }
 }

--- a/ETLBox/src/Definitions/TaskBase/DataFlowBatchDestination.cs
+++ b/ETLBox/src/Definitions/TaskBase/DataFlowBatchDestination.cs
@@ -22,6 +22,7 @@ namespace ALE.ETLBox.DataFlow
             }
         }
         private int batchSize;
+        private Task targetActionCompletionTask;
 
         internal BatchBlock<TInput> Buffer { get; set; }
         internal ActionBlock<TInput[]> TargetAction { get; set; }
@@ -33,6 +34,7 @@ namespace ALE.ETLBox.DataFlow
             Buffer = new BatchBlock<TInput>(batchSize);
             TargetAction = new ActionBlock<TInput[]>(d => WriteBatch(ref d));
             Buffer.LinkTo(TargetAction, new DataflowLinkOptions() { PropagateCompletion = true });
+            targetActionCompletionTask = TargetAction.Completion.ContinueWith(t => CleanUp());
             TypeInfo = new TypeInfo(typeof(TInput));
         }
 
@@ -69,15 +71,10 @@ namespace ALE.ETLBox.DataFlow
 
         public virtual void Wait()
         {
-            TargetAction.Completion.Wait();
-            CleanUp();
+            targetActionCompletionTask.Wait();
         }
 
-        public async Task Completion()
-        {
-            await TargetAction.Completion;
-            CleanUp();
-        }
+        public Task Completion => targetActionCompletionTask;
 
         private void CleanUp()
         {

--- a/ETLBox/src/Toolbox/DataFlow/DBMerge.cs
+++ b/ETLBox/src/Toolbox/DataFlow/DBMerge.cs
@@ -203,7 +203,7 @@ namespace ALE.ETLBox.DataFlow
         }
 
         public void Wait() => DestinationTable.Wait();
-        public async Task Completion() => await DestinationTable.Completion();
+        public async Task Completion() => await DestinationTable.Completion;
 
         public IDataFlowLinkSource<TInput> LinkTo(IDataFlowLinkTarget<TInput> target)
             => OutputSource.LinkTo(target);

--- a/ETLBox/src/Toolbox/DataFlow/MergeJoin.cs
+++ b/ETLBox/src/Toolbox/DataFlow/MergeJoin.cs
@@ -94,10 +94,7 @@ namespace ALE.ETLBox.DataFlow
             TargetBlock.Completion.Wait();
         }
 
-        public async Task Completion()
-        {
-            await TargetBlock.Completion;
-        }
+        public Task Completion => TargetBlock.Completion;
 
         public MergeJoinTarget(ITask parent, ITargetBlock<TInput> joinTarget)
         {
@@ -105,7 +102,6 @@ namespace ALE.ETLBox.DataFlow
             CopyTaskProperties(parent);
 
         }
-
     }
 
     /// <summary>

--- a/ETLBox/src/Toolbox/DataFlow/VoidDestination.cs
+++ b/ETLBox/src/Toolbox/DataFlow/VoidDestination.cs
@@ -26,7 +26,7 @@ namespace ALE.ETLBox.DataFlow
         }
 
         public void Wait() => _voidDestination.Wait();
-        public async Task Completion() => await _voidDestination.Completion();
+        public Task Completion => _voidDestination.Completion;
     }
 
     /// <summary>

--- a/TestsETLBox/src/DataFlowTests/CustomSource/CustomSourceAsyncTests.cs
+++ b/TestsETLBox/src/DataFlowTests/CustomSource/CustomSourceAsyncTests.cs
@@ -54,7 +54,7 @@ namespace ALE.ETLBoxTests.DataFlowTests
             DBDestination<MySimpleRow> dest = new DBDestination<MySimpleRow>(SqlConnection, "Destination4CustomSource");
             source.LinkTo(dest);
             Task sourceT = source.ExecuteAsync();
-            Task destT = dest.Completion();
+            Task destT = dest.Completion;
 
             //Assert
             Assert.True(RowCountTask.Count(SqlConnection, "Destination4CustomSource") == 0);
@@ -80,7 +80,7 @@ namespace ALE.ETLBoxTests.DataFlowTests
             Assert.Throws<ETLBoxException>(() =>
             {
                 Task sourceT = source.ExecuteAsync();
-                Task destT = dest.Completion();
+                Task destT = dest.Completion;
                 try
                 {
                     sourceT.Wait();

--- a/TestsETLBox/src/DataFlowTests/RowTransformation/RowTransformationFluentNotationTests.cs
+++ b/TestsETLBox/src/DataFlowTests/RowTransformation/RowTransformationFluentNotationTests.cs
@@ -45,7 +45,7 @@ namespace ALE.ETLBoxTests.DataFlowTests
             //Act
             source.LinkTo(trans1).LinkTo(trans2).LinkTo(trans3).LinkTo(dest);
             Task sourceT = source.ExecuteAsync();
-            Task destT = dest.Completion();
+            Task destT = dest.Completion;
 
             //Assert
             sourceT.Wait();
@@ -69,7 +69,7 @@ namespace ALE.ETLBoxTests.DataFlowTests
             //Act
             source.LinkTo(trans1, row => row.Col1 < 4, row => row.Col1 >= 4).LinkTo(dest);
             Task sourceT = source.ExecuteAsync();
-            Task destT = dest.Completion();
+            Task destT = dest.Completion;
 
             //Assert
             sourceT.Wait();

--- a/TestsNonParallel/src/Logging/DataFlowLoggingTests.cs
+++ b/TestsNonParallel/src/Logging/DataFlowLoggingTests.cs
@@ -183,7 +183,7 @@ namespace ALE.ETLBoxTests.Logging
             DBDestination dest = new DBDestination(SqlConnection, "Destination4CustomSource");
             source.LinkTo(dest);
             Task sourceT = source.ExecuteAsync();
-            Task destT = dest.Completion();
+            Task destT = dest.Completion;
 
             //Assert
             sourceT.Wait();


### PR DESCRIPTION
Hi,

I am hoping that you might give me your thoughts on this change.

I have changed the IDataFlowDestination.Completion() method to a property that no longer awaits. I find it more flexible to be able to await multiple destinations at the same time, rather than awaiting each individually.

I have also moved the CleanUp() call to a continuation of the TargetAction block.

Kind regards,
Ben