### PR TITLE
Added ConnectionManagerType to IConnectionManager interface.

### DIFF
--- a/ETLBox/src/Definitions/ConnectionManager/ConnectionManagerSpecifics.cs
+++ b/ETLBox/src/Definitions/ConnectionManager/ConnectionManagerSpecifics.cs
@@ -2,25 +2,6 @@
 {
     public class ConnectionManagerSpecifics
     {
-        public static ConnectionManagerType GetType(IConnectionManager connection)
-        {
-            if (connection.GetType() == typeof(SqlConnectionManager) ||
-                        connection.GetType() == typeof(SqlOdbcConnectionManager)
-                        )
-                return ConnectionManagerType.SqlServer;
-            else if (connection.GetType() == typeof(AccessOdbcConnectionManager))
-                return ConnectionManagerType.Access;
-            else if (connection.GetType() == typeof(AdomdConnectionManager))
-                return ConnectionManagerType.Adomd;
-            else if (connection.GetType() == typeof(SQLiteConnectionManager))
-                return ConnectionManagerType.SQLite;
-            else if (connection.GetType() == typeof(MySqlConnectionManager))
-                return ConnectionManagerType.MySql;
-            else if (connection.GetType() == typeof(PostgresConnectionManager))
-                return ConnectionManagerType.Postgres;
-            else return ConnectionManagerType.Unknown;
-        }
-
         public static string GetBeginQuotation(ConnectionManagerType type)
         {
             if (type == ConnectionManagerType.SqlServer || type == ConnectionManagerType.Access)
@@ -42,8 +23,8 @@
         }
 
 
-        public static string GetBeginQuotation(IConnectionManager connectionManager) => GetBeginQuotation(GetType(connectionManager));
-        public static string GetEndQuotation(IConnectionManager connectionManager) => GetEndQuotation(GetType(connectionManager));
+        public static string GetBeginQuotation(IConnectionManager connectionManager) => GetBeginQuotation(connectionManager.ConnectionManagerType);
+        public static string GetEndQuotation(IConnectionManager connectionManager) => GetEndQuotation(connectionManager.ConnectionManagerType);
 
 
     }

--- a/ETLBox/src/Definitions/ConnectionManager/DbConnectionManager.cs
+++ b/ETLBox/src/Definitions/ConnectionManager/DbConnectionManager.cs
@@ -8,6 +8,8 @@ namespace ALE.ETLBox.ConnectionManager
     public abstract class DbConnectionManager<Connection> : IDisposable, IConnectionManager
         where Connection : class, IDbConnection, new()
     {
+        public abstract ConnectionManagerType ConnectionManagerType { get; }
+        
         public int MaxLoginAttempts { get; set; } = 3;
         public bool LeaveOpen
         {

--- a/ETLBox/src/Definitions/ConnectionManager/IConnectionManager.cs
+++ b/ETLBox/src/Definitions/ConnectionManager/IConnectionManager.cs
@@ -6,6 +6,7 @@ namespace ALE.ETLBox.ConnectionManager
 {
     public interface IConnectionManager : IDisposable
     {
+        ConnectionManagerType ConnectionManagerType { get; }
         IDbConnectionString ConnectionString { get; set; }
         void Open();
         void Close();

--- a/ETLBox/src/Definitions/Database/TableDefinition.cs
+++ b/ETLBox/src/Definitions/Database/TableDefinition.cs
@@ -50,7 +50,7 @@ namespace ALE.ETLBox
         public static TableDefinition GetDefinitionFromTableName(IConnectionManager connection, string tableName)
         {
             IfTableOrViewExistsTask.ThrowExceptionIfNotExists(connection, tableName);
-            ConnectionManagerType connectionType = ConnectionManagerSpecifics.GetType(connection);
+            ConnectionManagerType connectionType = connection.ConnectionManagerType;
             ObjectNameDescriptor TN = new ObjectNameDescriptor(tableName, connectionType);
 
             if (connectionType == ConnectionManagerType.SqlServer)

--- a/ETLBox/src/Definitions/TaskBase/GenericTask.cs
+++ b/ETLBox/src/Definitions/TaskBase/GenericTask.cs
@@ -29,7 +29,7 @@ namespace ALE.ETLBox
             }
         }
 
-        public ConnectionManagerType ConnectionType => ConnectionManagerSpecifics.GetType(this.DbConnectionManager);
+        public ConnectionManagerType ConnectionType => this.DbConnectionManager.ConnectionManagerType;
         public string QB => ConnectionManagerSpecifics.GetBeginQuotation(this.ConnectionType);
         public string QE => ConnectionManagerSpecifics.GetEndQuotation(this.ConnectionType);
 

--- a/ETLBox/src/NLog/CreateDatabaseTarget.cs
+++ b/ETLBox/src/NLog/CreateDatabaseTarget.cs
@@ -9,7 +9,7 @@ namespace ALE.ETLBox.Logging
 
     public class CreateDatabaseTarget
     {
-        public ObjectNameDescriptor TN => new ObjectNameDescriptor(LogTableName, this.ConnectionType);
+        public ObjectNameDescriptor TN => new ObjectNameDescriptor(LogTableName, ConnectionManager.ConnectionManagerType);
         public string QB => TN.QB;
         public string QE => TN.QE;
         public string CommandText => $@"
@@ -31,20 +31,19 @@ SELECT {LogDate}
         {
             get
             {
-                if (ConnectionType == ConnectionManagerType.SqlServer || ConnectionType == ConnectionManagerType.MySql)
+                if (ConnectionManager.ConnectionManagerType == ConnectionManagerType.SqlServer || ConnectionManager.ConnectionManagerType == ConnectionManagerType.MySql)
                     return "CAST(@LogDate AS DATETIME)";
-                else if (ConnectionType == ConnectionManagerType.Postgres)
+                else if (ConnectionManager.ConnectionManagerType == ConnectionManagerType.Postgres)
                     return "CAST(@LogDate AS TIMESTAMP)";
                 else
                     return "@LogDate";
             }
         }
-        public string VARCHAR => this.ConnectionType == ConnectionManagerType.MySql ? "CHAR" : "VARCHAR";
-        public string INT => this.ConnectionType == ConnectionManagerType.MySql ? "UNSIGNED" : "INT";
+        public string VARCHAR => this.ConnectionManager.ConnectionManagerType == ConnectionManagerType.MySql ? "CHAR" : "VARCHAR";
+        public string INT => this.ConnectionManager.ConnectionManagerType == ConnectionManagerType.MySql ? "UNSIGNED" : "INT";
 
         public IConnectionManager ConnectionManager { get; set; }
         public string LogTableName { get; set; }
-        public ConnectionManagerType ConnectionType => ConnectionManagerSpecifics.GetType(ConnectionManager);
 
         public CreateDatabaseTarget(IConnectionManager connectionManager, string logTableName)
         {
@@ -67,11 +66,11 @@ SELECT {LogDate}
             AddParameter(dbTarget, "Logger", @"${logger}");
 
             dbTarget.CommandText = new NLog.Layouts.SimpleLayout(CommandText);
-            if (ConnectionType == ConnectionManagerType.Postgres)
+            if (ConnectionManager.ConnectionManagerType == ConnectionManagerType.Postgres)
                 dbTarget.DBProvider = "Npgsql.NpgsqlConnection, Npgsql";
-            else if (ConnectionType == ConnectionManagerType.MySql)
+            else if (ConnectionManager.ConnectionManagerType == ConnectionManagerType.MySql)
                 dbTarget.DBProvider = "MySql.Data.MySqlClient.MySqlConnection, MySql.Data";
-            else if (ConnectionType == ConnectionManagerType.SQLite)
+            else if (ConnectionManager.ConnectionManagerType == ConnectionManagerType.SQLite)
                 dbTarget.DBProvider = "System.Data.SQLite.SQLiteConnection, System.Data.SQLite";
             else
                 dbTarget.DBProvider = "Microsoft.Data.SqlClient.SqlConnection, Microsoft.Data.SqlClient";

--- a/ETLBox/src/Toolbox/ConnectionManager/Native/AdomdConnectionManager.cs
+++ b/ETLBox/src/Toolbox/ConnectionManager/Native/AdomdConnectionManager.cs
@@ -14,6 +14,8 @@ namespace ALE.ETLBox.ConnectionManager
     /// </example>
     public class AdomdConnectionManager : DbConnectionManager<AdomdConnection>
     {
+        public override ConnectionManagerType ConnectionManagerType { get; } = ConnectionManagerType.Adomd;
+        
         public AdomdConnectionManager() : base() { }
         public AdomdConnectionManager(SqlConnectionString connectionString) : base(connectionString) { }
         public AdomdConnectionManager(string connectionString) : base(new SqlConnectionString(connectionString)) { }

--- a/ETLBox/src/Toolbox/ConnectionManager/Native/MySqlConnectionManager.cs
+++ b/ETLBox/src/Toolbox/ConnectionManager/Native/MySqlConnectionManager.cs
@@ -13,6 +13,8 @@ namespace ALE.ETLBox.ConnectionManager
     /// </example>
     public class MySqlConnectionManager : DbConnectionManager<MySqlConnection>
     {
+        public override ConnectionManagerType ConnectionManagerType { get; } = ConnectionManagerType.MySql;
+        
         public MySqlConnectionManager() : base() { }
 
         public MySqlConnectionManager(MySqlConnectionString connectionString) : base(connectionString) { }

--- a/ETLBox/src/Toolbox/ConnectionManager/Native/PostgresConnectionManager.cs
+++ b/ETLBox/src/Toolbox/ConnectionManager/Native/PostgresConnectionManager.cs
@@ -15,6 +15,8 @@ namespace ALE.ETLBox.ConnectionManager
     /// </example>
     public class PostgresConnectionManager : DbConnectionManager<NpgsqlConnection>
     {
+        public override ConnectionManagerType ConnectionManagerType { get; } = ConnectionManagerType.Postgres;
+        
         public PostgresConnectionManager() : base() { }
 
         public PostgresConnectionManager(PostgresConnectionString connectionString) : base(connectionString) { }

--- a/ETLBox/src/Toolbox/ConnectionManager/Native/SqlConnectionManager.cs
+++ b/ETLBox/src/Toolbox/ConnectionManager/Native/SqlConnectionManager.cs
@@ -13,6 +13,8 @@ namespace ALE.ETLBox.ConnectionManager
     /// </example>
     public class SqlConnectionManager : DbConnectionManager<SqlConnection>
     {
+        public override ConnectionManagerType ConnectionManagerType { get; } = ConnectionManagerType.SqlServer;
+        
         public bool ModifyDBSettings { get; set; } = false;
 
         public SqlConnectionManager() : base() { }

--- a/ETLBox/src/Toolbox/ConnectionManager/Native/SqliteConnectionManager.cs
+++ b/ETLBox/src/Toolbox/ConnectionManager/Native/SqliteConnectionManager.cs
@@ -17,6 +17,8 @@ namespace ALE.ETLBox.ConnectionManager
     /// </example>
     public class SQLiteConnectionManager : DbConnectionManager<SQLiteConnection>
     {
+        public override ConnectionManagerType ConnectionManagerType { get; } = ConnectionManagerType.SQLite;
+        
         public bool ModifyDBSettings { get; set; } = false;
 
         public SQLiteConnectionManager() : base() { }

--- a/ETLBox/src/Toolbox/ConnectionManager/Odbc/AccessOdbcConnectionManager.cs
+++ b/ETLBox/src/Toolbox/ConnectionManager/Odbc/AccessOdbcConnectionManager.cs
@@ -31,6 +31,8 @@ namespace ALE.ETLBox.ConnectionManager
     /// </example>
     public class AccessOdbcConnectionManager :  OdbcConnectionManager
     {
+        public override ConnectionManagerType ConnectionManagerType { get; } = ConnectionManagerType.Access;
+        
         public AccessOdbcConnectionManager() : base() { }
         public AccessOdbcConnectionManager(OdbcConnectionString connectionString) : base(connectionString) { }
         public AccessOdbcConnectionManager(string connectionString) : base(new OdbcConnectionString(connectionString)) { }

--- a/ETLBox/src/Toolbox/ConnectionManager/Odbc/SqlOdbcConnectionManager.cs
+++ b/ETLBox/src/Toolbox/ConnectionManager/Odbc/SqlOdbcConnectionManager.cs
@@ -22,6 +22,8 @@ namespace ALE.ETLBox.ConnectionManager
     /// </example>
     public class SqlOdbcConnectionManager : OdbcConnectionManager
     {
+        public override ConnectionManagerType ConnectionManagerType { get; } = ConnectionManagerType.SqlServer;
+        
         public SqlOdbcConnectionManager() : base() { }
 
         public SqlOdbcConnectionManager(OdbcConnectionString connectionString) : base(connectionString) { }

--- a/TestsETLBox/src/DataFlowTests/DBDestination/DBDestinationForeignKeyTests.cs
+++ b/TestsETLBox/src/DataFlowTests/DBDestination/DBDestinationForeignKeyTests.cs
@@ -39,7 +39,7 @@ namespace ALE.ETLBoxTests.DataFlowTests
                     new TableColumn("Id", "INT", allowNulls:false, isPrimaryKey:true),
                     new TableColumn("Other", "VARCHAR(100)", allowNulls:true, isPrimaryKey:false),
                 });
-            ObjectNameDescriptor TN = new ObjectNameDescriptor(tablename, connection);
+            ObjectNameDescriptor TN = new ObjectNameDescriptor(tablename, connection.ConnectionManagerType);
             SqlTask.ExecuteNonQuery(connection, "Insert demo data"
                 , $@"INSERT INTO {TN.QuotatedFullName} VALUES(10,'TestX')");
         }
@@ -58,8 +58,8 @@ namespace ALE.ETLBoxTests.DataFlowTests
 
         void AddFKConstraint(IConnectionManager connection, string sourceTableName, string referenceTableName)
         {
-            ObjectNameDescriptor TN = new ObjectNameDescriptor(sourceTableName, connection);
-            ObjectNameDescriptor TNR = new ObjectNameDescriptor(referenceTableName, connection);
+            ObjectNameDescriptor TN = new ObjectNameDescriptor(sourceTableName, connection.ConnectionManagerType);
+            ObjectNameDescriptor TNR = new ObjectNameDescriptor(referenceTableName, connection.ConnectionManagerType);
             SqlTask.ExecuteNonQuery(connection, "Add FK constraint",
                 $@"ALTER TABLE {TN.QuotatedFullName}
 ADD CONSTRAINT constraint_fk
@@ -70,7 +70,7 @@ ON DELETE CASCADE;");
 
         void InsertTestData(IConnectionManager connection, string tableName)
         {
-            ObjectNameDescriptor TN = new ObjectNameDescriptor(tableName, connection);
+            ObjectNameDescriptor TN = new ObjectNameDescriptor(tableName, connection.ConnectionManagerType);
             SqlTask.ExecuteNonQuery(connection, "Insert demo data"
                     , $@"INSERT INTO {TN.QuotatedFullName} VALUES(1, 10 ,'Test1')");
             SqlTask.ExecuteNonQuery(connection, "Insert demo data"

--- a/TestsETLBox/src/DataFlowTests/DBDestination/DBDestinationSpecialCharacterTests.cs
+++ b/TestsETLBox/src/DataFlowTests/DBDestination/DBDestinationSpecialCharacterTests.cs
@@ -26,13 +26,13 @@ namespace ALE.ETLBoxTests.DataFlowTests
 
         private void InsertTestData(IConnectionManager connection, string tableName)
         {
-            var TN = new ObjectNameDescriptor(tableName, connection);
+            var TN = new ObjectNameDescriptor(tableName, connection.ConnectionManagerType);
             SqlTask.ExecuteNonQuery(connection, "Insert demo data"
                 , $@"INSERT INTO {TN.QuotatedFullName} VALUES(1,'\0 \"" \b \n \r \t \Z \\ \% \_ ')");
             SqlTask.ExecuteNonQuery(connection, "Insert demo data"
                 , $@"INSERT INTO {TN.QuotatedFullName} VALUES(2,' '' """" ')");
             SqlTask.ExecuteNonQuery(connection, "Insert demo data"
-                 , $@"INSERT INTO {TN.QuotatedFullName} VALUES(3,' !""§$%&/())='' ')");
+                 , $@"INSERT INTO {TN.QuotatedFullName} VALUES(3,' !""ï¿½$%&/())='' ')");
             SqlTask.ExecuteNonQuery(connection, "Insert demo data"
                 , $@"INSERT INTO {TN.QuotatedFullName} VALUES(4,NULL)");
         }

--- a/TestsETLBox/src/DataFlowTests/DBMerge/DBMergeCompositeKeysTests.cs
+++ b/TestsETLBox/src/DataFlowTests/DBMerge/DBMergeCompositeKeysTests.cs
@@ -81,8 +81,8 @@ namespace ALE.ETLBoxTests.DataFlowTests
         public void MergeWithCompositeKey(IConnectionManager connection)
         {
             //Arrange
-            ObjectNameDescriptor TNS = new ObjectNameDescriptor("DBMergeSource", connection);
-            ObjectNameDescriptor TND = new ObjectNameDescriptor("DBMergeDestination", connection);
+            ObjectNameDescriptor TNS = new ObjectNameDescriptor("DBMergeSource", connection.ConnectionManagerType);
+            ObjectNameDescriptor TND = new ObjectNameDescriptor("DBMergeDestination", connection.ConnectionManagerType);
             ReCreateTable(connection, TNS);
             ReCreateTable(connection, TND);
             InsertSourceData(connection, TNS);

--- a/TestsETLBox/src/DataFlowTests/DBSource/DBSourceErrorLinkingTests.cs
+++ b/TestsETLBox/src/DataFlowTests/DBSource/DBSourceErrorLinkingTests.cs
@@ -90,7 +90,7 @@ namespace ALE.ETLBoxTests.DataFlowTests
                 new TableColumn("Col3", "VARCHAR(100)", allowNulls: true)
             });
             TableDefinition.CreateTable(connection);
-            ObjectNameDescriptor TN = new ObjectNameDescriptor(tableName, connection);
+            ObjectNameDescriptor TN = new ObjectNameDescriptor(tableName, connection.ConnectionManagerType);
             SqlTask.ExecuteNonQuery(connection, "Insert demo data"
               , $@"INSERT INTO {TN.QuotatedFullName} VALUES('1','Test1','1')");
             SqlTask.ExecuteNonQuery(connection, "Insert demo data"

--- a/TestsETLBox/src/DataFlowTests/LookupTransformation/LookupErrorLinkingTests.cs
+++ b/TestsETLBox/src/DataFlowTests/LookupTransformation/LookupErrorLinkingTests.cs
@@ -128,7 +128,7 @@ namespace ALE.ETLBoxTests.DataFlowTests
                 new TableColumn("Col2", "VARCHAR(100)", allowNulls: true)
             });
             TableDefinition.CreateTable(connection);
-            ObjectNameDescriptor TN = new ObjectNameDescriptor(tableName, connection);
+            ObjectNameDescriptor TN = new ObjectNameDescriptor(tableName, connection.ConnectionManagerType);
             SqlTask.ExecuteNonQuery(connection, "Insert demo data"
               , $@"INSERT INTO {TN.QuotatedFullName} VALUES('1','Test1')");
             SqlTask.ExecuteNonQuery(connection, "Insert demo data"

--- a/TestsETLBox/src/Fixtures/FourColumnsTableFixture.cs
+++ b/TestsETLBox/src/Fixtures/FourColumnsTableFixture.cs
@@ -17,7 +17,7 @@ namespace ALE.ETLBoxTests.Fixtures
         public bool IsSQLiteConnection => this.Connection.GetType() == typeof(SQLiteConnectionManager);
         public TableDefinition TableDefinition { get; set; }
         public string TableName { get; set; }
-        public ObjectNameDescriptor TN => new ObjectNameDescriptor(TableName, Connection);
+        public ObjectNameDescriptor TN => new ObjectNameDescriptor(TableName, Connection.ConnectionManagerType);
         public string QB => TN.QB;
         public string QE => TN.QE;
         public FourColumnsTableFixture(string tableName)

--- a/TestsETLBox/src/Fixtures/TwoColumnsTableFixture.cs
+++ b/TestsETLBox/src/Fixtures/TwoColumnsTableFixture.cs
@@ -15,7 +15,7 @@ namespace ALE.ETLBoxTests.Fixtures
         public TableDefinition TableDefinition { get; set; }
         public string TableName { get; set; }
 
-        public ObjectNameDescriptor TN => new ObjectNameDescriptor(TableName, Connection);
+        public ObjectNameDescriptor TN => new ObjectNameDescriptor(TableName, Connection.ConnectionManagerType);
         public string QB => TN.QB;
         public string QE => TN.QE;
 


### PR DESCRIPTION
Small refactoring. ConnectionManagerSpecifics should be removed in future because of hardcoded DB types.
Added ConnectionManagerType to IConnectionManager. It's temporary solution, because ConnectionManagerType is not extendable itself and should be refactored in future.